### PR TITLE
Fixed unicode error on resources page

### DIFF
--- a/jars/cookies/forms.py
+++ b/jars/cookies/forms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django import forms
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -91,14 +92,14 @@ class BulkResourceForm(forms.Form):
         help_text='If selected, if a file in this upload shares a name with' +\
         ' an existing resource it will simply be ignored. Otherwise, its name'+\
         ' will be modified slightly so that it is unique.')
-        
+
     def __init__(self, *args, **kwargs):
 		try:
 			self.choices += [(t.id,t.name) for t in Type.objects.filter(
 							 real_type__model__in=['type', 'concepttype'])]
 		except OperationalError:
-			pass    
-		super(BulkResourceForm, self).__init__(*args, **kwargs)			
+			pass
+		super(BulkResourceForm, self).__init__(*args, **kwargs)
 
 class ChooseResourceTypeForm(forms.Form):
     RTYPES = (
@@ -106,7 +107,7 @@ class ChooseResourceTypeForm(forms.Form):
         ('remoteresource', 'Remote'),
         ('bulk', 'Bulk'),
     )
-    
+
     # The description attribute is rendered in admin/generic_form.html
     description = 'Resources can be local (e.g. a text that you upload) or' + \
                   ' remote (e.g. a text in someone else\'s repository. You' + \
@@ -123,29 +124,29 @@ class TargetField(forms.models.ModelChoiceField):
         """
         Supposed to convert a value entered into the field into an appropriate
         Python object for storage.
-        
-        In fact, here we just pass the value (str/unicode) on through, so that 
+
+        In fact, here we just pass the value (str/unicode) on through, so that
         we can evaluate it in :meth:`.RelationForm.clean`\.
         """
-        
+
         return value
 
     def prepare_value(self, value):
         """
         Converts a Python object (``value``) back into something that we can
         display in the form.
-        
+
         If value is an int, it is a primary key for :class:.`Entity`\. Otherwise
-        (e.g. where there was a ValidationError) it is a value for ``name`` and 
+        (e.g. where there was a ValidationError) it is a value for ``name`` and
         should be displayed directly.
         """
-    
+
         if value is not None:
             try:    # Try to cast the value as an int.
                 value = int(value)
             except:
                 pass
-            
+
             if type(value) is int:
                 entity = Entity.objects.get(pk=value)
                 return entity.name
@@ -165,26 +166,26 @@ class ResourceForm(forms.ModelForm):
     def clean_name(self):
         """
         Ensure that an :class:`.Entity` with this name does not already exist.
-        
+
         This is necessary because Django only checks against objects of the
         instantiated subclass, but we want to enforce the UNIQUE constraint
         across all Entities.
         """
-        
+
         name = self.cleaned_data['name']
-        
+
         # Look for Entities with the name that the user entered.
         matching = Entity.objects.filter(name=name)
-        
+
         # count() minimizes database impact.
         if matching.count() > 0:
-        
+
             # If instance.id is None, this is a new Resource; matching names
             #  should not be allowed under any circumstance. If the instance
             #  is the same as the only matching Entity, then the user is simply
             #  updating an existing Resource and a match is allowed.
             if self.instance.id is None or matching[0].id != self.instance.id:
-            
+
                 # Add an error to be displayed above the name input.
                 self._errors['name'] = self.error_class(
                     ['Something with that name already exists.']
@@ -209,12 +210,12 @@ class RelationForm(forms.ModelForm):
     """
     Supports the :class:`.RelationInline` by handling heterogeneous input and
     resolving them into Entities.
-    
+
     TODO: Handle cases where the range of a Field includes non-Value types.
     """
-    
+
     model = Relation
-    
+
     def __init__(self, *args, **kwargs):
         super(RelationForm, self).__init__(*args, **kwargs)
 
@@ -224,7 +225,7 @@ class RelationForm(forms.ModelForm):
         #  RelationForm.clean(), below.
         self.fields['target'] = TargetField(
                                     queryset=Entity.objects.all()    )
-                                    
+
         # This autocomplete widget handles all Entity objects in the system. The
         #  desired outcome is that the user can use the same widget to select
         #  (and, in the case of Values, create) target Entities that are within
@@ -245,7 +246,7 @@ class RelationForm(forms.ModelForm):
                 'class': 'autocomplete_filter',
                 'target': 'target',
             })
-        
+
         # Sort predicate Fields alphabetically, by name.
         qs = self.fields['predicate'].queryset.extra(order_by=['name'])
         self.fields['predicate'].queryset = qs
@@ -258,10 +259,10 @@ class RelationForm(forms.ModelForm):
         This custom :meth:`.clean` method adds extra data handling and
         validation for the ``target`` field.
         """
-    
+
         # First get the usual cleanining out of the way.
         cleaned_data = super(RelationForm, self).clean()
-        
+
         # Our main objective is to ensure that the selected target Entity is
         #  appropriate given the selected predicate Field. In other words,
         #  whether the Entity's "real" class is in the predicate Field's range.
@@ -273,7 +274,7 @@ class RelationForm(forms.ModelForm):
         #  target Entity is a Value of some kind -- we will want to create a new
         #  Entity to store that input.
         target_data = cleaned_data.get('target')
-        
+
         # Target data can't be blank.
         if len(target_data) == 0:
             self._errors['target'] = self.error_class(
@@ -281,37 +282,37 @@ class RelationForm(forms.ModelForm):
                                         )
             del cleaned_data['target']
             return cleaned_data     # We're completely done here.
-        
+
         # First, attempt to get an Entity by name. At this point we don't know
         #  what kind of Entity it is (i.e. which subclass).
         try:
             results = Entity.objects.filter(name=target_data)
 
             target_obj = Entity.objects.get(name=target_data)
-            
-        
+
+
         # If that fails, try to cast the data based on any System fields in the
         #  predicate Field's range.
         except ObjectDoesNotExist:
-            
+
             # Some Fields have an explicit range. If that's true for this
             #  predicate, we can use that to try to generate a Value for the
             #  target.
             if predicate.range.count() > 0:
-            
+
                 # Try to get a model for each System type in the predicate's
                 #  range.
                 cast = False
                 for ftype in predicate.range.all():
                     if ftype.schema.name == 'System':
-                    
+
                         # It is unlikely, but if there is no model corresponding
                         #  to the System type (ftype), then we should move on.
                         try:
                             candidate = md.__dict__[ftype.name]
                         except:
                             continue
-                        
+
                         # If the model is retrieved successfully, we instantiate
                         #  it and assign the data to its name attribute.
                         try:
@@ -320,13 +321,13 @@ class RelationForm(forms.ModelForm):
                                                             )[0]
 
                             target_obj = target_obj.cast()
-                            
+
                             # If the data is successfully cast as the selected
                             #  model, then we will stop here and proceed with
                             #  saving the Relation.
                             cast = True     # Evaluated below.
                             break
-                            
+
                         # Otherwise, move on to the next type in the predicate's
                         #  range.
                         except (ValidationError, ValueError):
@@ -354,7 +355,7 @@ class RelationForm(forms.ModelForm):
 
         # If we made it this far, then we have succesfully created or retrieved
         #  an Entity that is a candidate for the Relation's target.
-        
+
         # The cast() method will return the Entity retrieved above, but as an
         #  instance of its "real" class.
         target_obj = target_obj.cast()
@@ -363,19 +364,19 @@ class RelationForm(forms.ModelForm):
         #  empty, then any Entity will do.
         if predicate.range.count() > 0:
             range = predicate.range.all()   # This is the database hit.
-            
+
             # This should be an informative error message.
             range_msg = 'Value must be one of: {0}'.format(
                             ', '.join([str(r) for r in range])  )
-            
+
             # The target Entity may nor may not have a Type associated with it.
             if hasattr(target_obj, 'entity_type'):
-            
+
                 # Here we check wheter the Entity's type is in range.
                 if not target_obj.entity_type in range:
                     self._errors['target'] = self.error_class([range_msg])
                     del cleaned_data['target']
-            
+
             # If the predicate has a range and the down-cast Entity has no type,
             #  there is no way for the Entity to be in range.
             else:
@@ -385,4 +386,3 @@ class RelationForm(forms.ModelForm):
         # Success! Update cleaned_data to include the target Entity.
         cleaned_data['target'] = target_obj
         return cleaned_data
-


### PR DESCRIPTION
Added a import statement to fix unicode issue on forms.py
<code> from __future__ import unicode_literals</code>

Reference:  https://docs.djangoproject.com/en/1.8/ref/unicode/

This fixed the unicode error issue on resources page:
<img width="1279" alt="screen shot 2015-09-25 at 5 34 23 pm" src="https://cloud.githubusercontent.com/assets/8482721/10114766/afe70a40-63ab-11e5-8ec6-b031c0e0d0f2.png">
